### PR TITLE
240716

### DIFF
--- a/baekjoon/DFS와_BFS.java
+++ b/baekjoon/DFS와_BFS.java
@@ -3,6 +3,13 @@ package baekjoon;
 import java.util.*;
 import java.io.*;
 
+/**
+ * 시간복잡도 : O(N + M + NlogN)
+ * 		초기화 O(N) + 노드 입력 O(M) + 정렬 O(NlogN) + DFS O(N + M) + BFS O(N + M)
+ * 		BFS / DFS : visit을 통해서 모든 노드(N)와 간선(M)에 한번씩만 방문한다
+ * 메모리 : 20380 KB (128 MB)
+ * 시간 : 280 ms (2 s)
+ */
 public class DFS와_BFS {
 
 	private static int N, M, V;
@@ -16,6 +23,7 @@ public class DFS와_BFS {
 	public static void main(String[] args) throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
+		// step 1 - input
 		StringTokenizer st = new StringTokenizer(br.readLine());
 		N = Integer.parseInt(st.nextToken());
 		M = Integer.parseInt(st.nextToken());
@@ -23,6 +31,7 @@ public class DFS와_BFS {
 
 		nodeList = new ArrayList[N+1];
 
+		// 간선이 없는 노드도 있겠지만 모든 노드에 대해 초기화 안하면 nullPointer exception 발생
 		for (int i = 1; i <= N; ++i) {
 			nodeList[i] = new ArrayList<>();
 		}
@@ -37,18 +46,22 @@ public class DFS와_BFS {
 			nodeList[node2].add(node1);
 		}
 
+		// step 2 - sort : 번호가 작은 노드부터 방문하기 위함
 		for (int i = 1; i <= N; ++i) {
 			if (nodeList[i].size() == 0) continue;
 
 			Collections.sort(nodeList[i]);
 		}
 
+		// step 3 - DFS
 		visit = new boolean[N+1];
 		dfs(V);
 
+		// step 4 - BFS
 		visit = new boolean[N+1];
 		bfs(V);
 
+		// step 5 - output
 		System.out.println(sbDFS);
 		System.out.println(sbBFS);
 	}

--- a/baekjoon/DFS와_BFS.java
+++ b/baekjoon/DFS와_BFS.java
@@ -4,7 +4,83 @@ import java.util.*;
 import java.io.*;
 
 public class DFS와_BFS {
-	public static void main(String[] args) throws IOException {
 
+	private static int N, M, V;
+
+	private static List<Integer>[] nodeList;
+	private static boolean[] visit;
+
+	private static StringBuilder sbDFS = new StringBuilder();
+	private static StringBuilder sbBFS = new StringBuilder();
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		V = Integer.parseInt(st.nextToken());
+
+		nodeList = new ArrayList[N+1];
+
+		for (int i = 1; i <= N; ++i) {
+			nodeList[i] = new ArrayList<>();
+		}
+
+		for (int i = 0; i < M; ++i) {
+			st = new StringTokenizer(br.readLine());
+
+			int node1 = Integer.parseInt(st.nextToken());
+			int node2 = Integer.parseInt(st.nextToken());
+
+			nodeList[node1].add(node2);
+			nodeList[node2].add(node1);
+		}
+
+		for (int i = 1; i <= N; ++i) {
+			if (nodeList[i].size() == 0) continue;
+
+			Collections.sort(nodeList[i]);
+		}
+
+		visit = new boolean[N+1];
+		dfs(V);
+
+		visit = new boolean[N+1];
+		bfs(V);
+
+		System.out.println(sbDFS);
+		System.out.println(sbBFS);
+	}
+
+	private static void dfs(int now) {
+		visit[now] = true;
+
+		sbDFS.append(now + " ");
+
+		for (int next : nodeList[now]) {
+			if (!visit[next])
+				dfs(next);
+		}
+	}
+
+	private static void bfs(int start) {
+		Queue<Integer> q = new LinkedList<>();
+		q.add(start);
+
+		visit[start] = true;
+
+		while (!q.isEmpty()) {
+			int now = q.poll();
+
+			sbBFS.append(now + " ");
+
+			for (int next : nodeList[now]) {
+				if (visit[next]) continue;
+
+				visit[next] = true;
+				q.add(next);
+			}
+		}
 	}
 }

--- a/baekjoon/DFS와_BFS.java
+++ b/baekjoon/DFS와_BFS.java
@@ -1,0 +1,10 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+public class DFS와_BFS {
+	public static void main(String[] args) throws IOException {
+
+	}
+}

--- a/baekjoon/바이러스_2606.java
+++ b/baekjoon/바이러스_2606.java
@@ -4,7 +4,75 @@ import java.io.*;
 import java.util.*;
 
 public class 바이러스_2606 {
-	public static void main(String[] args) {
 
+	private static int N, M;
+
+	private static List<Integer>[] nodeList;
+	private static boolean[] visit;
+
+	private static int virus = 0;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		N = Integer.parseInt(br.readLine());
+		M = Integer.parseInt(br.readLine());
+
+		visit = new boolean[N+1];
+		nodeList = new ArrayList[N+1];
+
+		for (int i = 1; i <= N; ++i) {
+			nodeList[i] = new ArrayList<>();
+		}
+
+		StringTokenizer st;
+		for (int i = 0; i < M; ++i) {
+			st = new StringTokenizer(br.readLine());
+
+			int node1 = Integer.parseInt(st.nextToken());
+			int node2 = Integer.parseInt(st.nextToken());
+
+			nodeList[node1].add(node2);
+			nodeList[node2].add(node1);
+		}
+
+		bfs(1);
+
+		// dfs(1);
+
+		System.out.println(--virus);
+	}
+
+	private static void bfs(int start) {
+		Queue<Integer> q = new LinkedList<>();
+		q.add(start);
+
+		visit[start] = true;
+
+		while (!q.isEmpty()) {
+			int now = q.poll();
+
+			virus++;
+
+			for (int next : nodeList[now]) {
+				if (!visit[next]) {
+					visit[next] = true;
+					q.add(next);
+				}
+			}
+		}
+	}
+
+	private static void dfs(int now) {
+		visit[now] = true;
+
+		virus++;
+
+		for (int next : nodeList[now]) {
+			if (!visit[next]) {
+				visit[next] = true;
+				dfs(next);
+			}
+		}
 	}
 }

--- a/baekjoon/바이러스_2606.java
+++ b/baekjoon/바이러스_2606.java
@@ -1,0 +1,10 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+public class 바이러스_2606 {
+	public static void main(String[] args) {
+
+	}
+}

--- a/baekjoon/바이러스_2606.java
+++ b/baekjoon/바이러스_2606.java
@@ -3,6 +3,13 @@ package baekjoon;
 import java.io.*;
 import java.util.*;
 
+/**
+ * 시간복잡도 : O(M + N)
+ * 		초기화 O(N) + 입력 O(M) + dfs / bfs O(N + M)
+ * 메모리 : 14136 KB
+ * 시간 : 104 ms (BFS랑 DFS랑 큰 차이 없음)
+ */
+
 public class 바이러스_2606 {
 
 	private static int N, M;
@@ -15,6 +22,7 @@ public class 바이러스_2606 {
 	public static void main(String[] args) throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
+		// step 1 - 입력
 		N = Integer.parseInt(br.readLine());
 		M = Integer.parseInt(br.readLine());
 
@@ -36,6 +44,7 @@ public class 바이러스_2606 {
 			nodeList[node2].add(node1);
 		}
 
+		// step 2 - 계산
 		bfs(1);
 
 		// dfs(1);

--- a/baekjoon/연결요소의_개수_11724.java
+++ b/baekjoon/연결요소의_개수_11724.java
@@ -1,0 +1,10 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+public class 연결요소의_개수_11724 {
+	public static void main(String[] args) throws IOException {
+
+	}
+}

--- a/baekjoon/연결요소의_개수_11724.java
+++ b/baekjoon/연결요소의_개수_11724.java
@@ -4,7 +4,56 @@ import java.util.*;
 import java.io.*;
 
 public class 연결요소의_개수_11724 {
-	public static void main(String[] args) throws IOException {
 
+	private static int N, M;
+
+	private static List<Integer>[] nodeList;
+	private static boolean[] isVisit;
+
+	private static int countOfGraph = 0;
+
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		nodeList = new ArrayList[N+1];
+		isVisit = new boolean[N+1];
+		for (int i = 1; i <= N; ++i) {
+			nodeList[i] = new ArrayList<>();
+		}
+
+		for (int i = 0; i < M; ++i) {
+			st = new StringTokenizer(br.readLine());
+
+			int node1 = Integer.parseInt(st.nextToken());
+			int node2 = Integer.parseInt(st.nextToken());
+
+			nodeList[node1].add(node2);
+			nodeList[node2].add(node1);
+		}
+
+		for (int i = 1; i <= N; ++i) {
+			if (!isVisit[i]) {
+				findGraph(i);
+				countOfGraph++;
+			}
+		}
+
+		bw.write(countOfGraph + "\n");
+		bw.close();
+		br.close();
+	}
+
+	private static void findGraph(int now) {
+		isVisit[now] = true;
+		for (int next : nodeList[now]) {
+			if (!isVisit[next])
+				findGraph(next);
+		}
 	}
 }

--- a/baekjoon/연결요소의_개수_11724.java
+++ b/baekjoon/연결요소의_개수_11724.java
@@ -17,7 +17,7 @@ public class 연결요소의_개수_11724 {
 	private static int N, M;
 
 	private static List<Integer>[] nodeList;	// 간선으로 연결된 노드 리스트
-	private static boolean[] isVisit;			// bfs용
+	private static boolean[] isVisit;			// dfs용
 
 	private static int countOfGraph = 0;
 

--- a/baekjoon/연결요소의_개수_11724.java
+++ b/baekjoon/연결요소의_개수_11724.java
@@ -3,12 +3,21 @@ package baekjoon;
 import java.util.*;
 import java.io.*;
 
+/**
+ * 시간복잡도 : O(N)
+ * 		입력 O(N) + 그래프 계산 O(N)
+ *
+ * 메모리 : 141776 KB (512 MB)
+ * 시간 : sout - 612 ms / bw - 720 ms (3 s)
+ * 		(출력이 복잡하지 않은 상태에서는 큰 차이 없는 듯?)
+ */
+
 public class 연결요소의_개수_11724 {
 
 	private static int N, M;
 
-	private static List<Integer>[] nodeList;
-	private static boolean[] isVisit;
+	private static List<Integer>[] nodeList;	// 간선으로 연결된 노드 리스트
+	private static boolean[] isVisit;			// bfs용
 
 	private static int countOfGraph = 0;
 
@@ -17,6 +26,7 @@ public class 연결요소의_개수_11724 {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
 
+		// step 1 - 입력
 		StringTokenizer st = new StringTokenizer(br.readLine());
 		N = Integer.parseInt(st.nextToken());
 		M = Integer.parseInt(st.nextToken());
@@ -33,10 +43,12 @@ public class 연결요소의_개수_11724 {
 			int node1 = Integer.parseInt(st.nextToken());
 			int node2 = Integer.parseInt(st.nextToken());
 
+			// 각 노드에 연결된 다른 노드들을 리스트로 갖고 있음
 			nodeList[node1].add(node2);
 			nodeList[node2].add(node1);
 		}
 
+		// step 2 - 그래프 계산. bfs
 		for (int i = 1; i <= N; ++i) {
 			if (!isVisit[i]) {
 				findGraph(i);
@@ -44,11 +56,18 @@ public class 연결요소의_개수_11724 {
 			}
 		}
 
+		// step 3 - 출력
 		bw.write(countOfGraph + "\n");
 		bw.close();
 		br.close();
 	}
 
+	/**
+	 * now node와 연결된 next node, next, next, ... 이런식으로 그래프를 쭉 순회함 => BFS 방식
+	 * 순회가 끝나면 하나의 그래프가 끝이 난 것
+	 *
+	 * @param now 현재 노드의 index
+	 */
 	private static void findGraph(int now) {
 		isVisit[now] = true;
 		for (int next : nodeList[now]) {

--- a/baekjoon/연결요소의_개수_11724.java
+++ b/baekjoon/연결요소의_개수_11724.java
@@ -48,7 +48,7 @@ public class 연결요소의_개수_11724 {
 			nodeList[node2].add(node1);
 		}
 
-		// step 2 - 그래프 계산. bfs
+		// step 2 - 그래프 계산. dfs
 		for (int i = 1; i <= N; ++i) {
 			if (!isVisit[i]) {
 				findGraph(i);
@@ -63,7 +63,7 @@ public class 연결요소의_개수_11724 {
 	}
 
 	/**
-	 * now node와 연결된 next node, next, next, ... 이런식으로 그래프를 쭉 순회함 => BFS 방식
+	 * now node와 연결된 next node, next, next, ... 이런식으로 그래프를 쭉 순회함 => DFS 방식
 	 * 순회가 끝나면 하나의 그래프가 끝이 난 것
 	 *
 	 * @param now 현재 노드의 index


### PR DESCRIPTION
- 그래프 문항에서는 DFS/BFS 간의 시간차이가 거의 없다. 어차피 모든 노드(N) + 모든 간선(M)을 한번씩 방문해야하기 때문인듯
- 간선이 일방향일 경우 문제 난이도가 달라질 것 같다. 삼성에서 일방향/양방향 이런거 나왔던 것 같은데(?)
- 어제 풀었던 트리 문제가 그래프로 접근하면 되는거였군

- nodeList[][]에 대해 사용하지 않는 인덱스여도 초기화가 안되어있으면 null pointer exception 발생할 수 있다. 사용여부는 size()==0으로 판단하자 

## 연결요소의 개수
* 소요시간 : 20분
 * 시간복잡도 : O(N)
 * 메모리 : 141776 KB (512 MB)
 * 시간 : sout - 612 ms / bw - 720 ms (3 s)
  _출력이 복잡하지 않은 상태에서는 큰 차이 없는 듯?_

## DFS와 BFS
* 소요시간 : 40분
 * 시간복잡도 : O(N + M + NlogN)
 * 메모리 : 20380 KB (128 MB)
 * 시간 : 280 ms (2 s)
_모든 정점을 방문해야하는줄 알고 헤맸음._

## 바이러스
* 소요시간 : 15분
 * 시간복잡도 : O(M + N)
 * 메모리 : 14136 KB
 * 시간 : 104 ms (BFS랑 DFS랑 큰 차이 없음)