### PR TITLE
240729

### DIFF
--- a/baekjoon/구슬찾기_2617.java
+++ b/baekjoon/구슬찾기_2617.java
@@ -4,19 +4,24 @@ import java.io.*;
 import java.util.*;
 
 public class 구슬찾기_2617 {
-
 	private static int N, M;
 	private static Tree[] marble;
-
-	private static Set<Integer> lightSet;
-	private static Set<Integer> heavySet;
+	private static boolean[] lightArr, heavyArr;
 
 	private static class Tree {
-		Set<Integer> light, heavy;
+		boolean[] light, heavy;
+		int lightCount = 0, heavyCount = 0;
 
-		Tree() {
-			light = new HashSet<>();
-			heavy = new HashSet<>();
+		Tree(int n) {
+			light = new boolean[n];
+			heavy = new boolean[n];
+		}
+
+		void setCount() {
+			for (int i = 0; i < N; ++i) {
+				if (light[i]) lightCount++;
+				if (heavy[i]) heavyCount++;
+			}
 		}
 	}
 	public static void main(String[] args) throws IOException {
@@ -28,7 +33,7 @@ public class 구슬찾기_2617 {
 
 		marble = new Tree[N];
 		for (int i = 0; i < N; ++i) {
-			marble[i] = new Tree();
+			marble[i] = new Tree(N);
 		}
 
 		for (int i = 0; i < M; ++i) {
@@ -36,40 +41,36 @@ public class 구슬찾기_2617 {
 			int mh = Integer.parseInt(st.nextToken()) - 1;
 			int ml = Integer.parseInt(st.nextToken()) - 1;
 
-			marble[mh].light.add(ml);
-			marble[ml].heavy.add(mh);
+			marble[mh].light[ml] = true;
+			marble[ml].heavy[mh] = true;
 
 		}
 
 		for (int i = 0; i < N; ++i) {
-			lightSet = new HashSet<>();
-			heavySet = new HashSet<>();
+			lightArr = new boolean[N];
+			heavyArr = new boolean[N];
 
 			checkLight(i, i);
 			checkHeavy(i, i);
 
-			marble[i].light.addAll(lightSet);
-			marble[i].heavy.addAll(heavySet);
-
+			marble[i].setCount();
 		}
 
 		System.out.println(findNoMiddle());
 	}
 
 	private static void checkLight(int root, int now) {
-		if (marble[now].light.isEmpty()) return;
-
-		for (int next : marble[now].light) {
-			lightSet.add(next);
+		for (int next =  0; next < N; ++next) {
+			if (marble[now].light[next] == false) continue;
+			marble[root].light[next] = true;
 			checkLight(root, next);
 		}
 	}
 
 	private static void checkHeavy(int root, int now) {
-		if (marble[now].heavy.isEmpty()) return;
-
-		for (int next : marble[now].heavy) {
-			heavySet.add(next);
+		for (int next =  0; next < N; ++next) {
+			if (marble[now].heavy[next] == false) continue;
+			marble[root].heavy[next] = true;
 			checkHeavy(root, next);
 		}
 	}
@@ -81,8 +82,8 @@ public class 구슬찾기_2617 {
 
 		int noMid = 0;
 		for (int i = 0; i < N; ++i) {
-			if (marble[i].light.size() > lightCount
-				|| marble[i].heavy.size() > heavyCount) noMid++;
+			if (marble[i].lightCount > lightCount
+				|| marble[i].heavyCount > heavyCount) noMid++;
 		}
 
 		return noMid;

--- a/baekjoon/구슬찾기_2617.java
+++ b/baekjoon/구슬찾기_2617.java
@@ -3,10 +3,22 @@ package baekjoon;
 import java.io.*;
 import java.util.*;
 
+/**
+ * 풀이시간 : 1시간 반
+ * 메모리 : 15960 KB
+ * 시간 : 216 ms
+ * 시간복잡도 : O(N * (N + E))
+ *
+ * 1. hashMap & List 써서 트리로 구현 => 메모리 초과
+ * 		: Integer 객체의 크기와 hashMap 자체적인 공간 할당 구조 때문인듯 함
+ * 2. boolean[] 써서 가벼운 구슬, 무거운 구슬 찾고난 후 개수 세기 => 시간초과
+ * 		: true인 구슬을 찾기 위해 계속 loop 돌아야함
+ * 3. boolean[] 사용하되, check 함수에서 가벼운/무거운 구슬 찾음과 동시에 개수 세기, visit 사용 => 정답
+ */
 public class 구슬찾기_2617 {
 	private static int N, M;
 	private static Tree[] marble;
-	private static boolean[] lightArr, heavyArr;
+	private static boolean[] lightVisit, heavyVisit;
 
 	private static class Tree {
 		boolean[] light, heavy;
@@ -16,17 +28,11 @@ public class 구슬찾기_2617 {
 			light = new boolean[n];
 			heavy = new boolean[n];
 		}
-
-		void setCount() {
-			for (int i = 0; i < N; ++i) {
-				if (light[i]) lightCount++;
-				if (heavy[i]) heavyCount++;
-			}
-		}
 	}
 	public static void main(String[] args) throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 
+		// step 1 - 입력
 		StringTokenizer st = new StringTokenizer(br.readLine());
 		N = Integer.parseInt(st.nextToken());
 		M = Integer.parseInt(st.nextToken());
@@ -46,35 +52,81 @@ public class 구슬찾기_2617 {
 
 		}
 
+		// step 2 - i번째 구슬보다 더 가벼운 / 무거운 구슬의 개수를 센다
 		for (int i = 0; i < N; ++i) {
-			lightArr = new boolean[N];
-			heavyArr = new boolean[N];
+			lightVisit = new boolean[N];
+			heavyVisit = new boolean[N];
 
-			checkLight(i, i);
-			checkHeavy(i, i);
-
-			marble[i].setCount();
+			checkLight(i);
+			checkHeavy(i);
 		}
 
+		// step 3 - mid가 될 수 없는 구슬을 찾는다
 		System.out.println(findNoMiddle());
 	}
 
-	private static void checkLight(int root, int now) {
-		for (int next =  0; next < N; ++next) {
-			if (marble[now].light[next] == false) continue;
-			marble[root].light[next] = true;
-			checkLight(root, next);
+	/**
+	 * step 2 (1) 가벼운 구슬을 찾는 함수 (bfs)
+	 *
+	 * @param root i 번째 구슬 (트리에서 부모 노드 역할)
+	 */
+	private static void checkLight(int root) {
+		Queue<Integer> q = new LinkedList<>();
+
+		q.add(root);
+		lightVisit[root] = true;
+
+		int count = -1;
+
+		while(!q.isEmpty()) {
+			int now = q.poll();
+			count++;
+			for (int i = 0; i < N; ++i) {
+				if (!marble[now].light[i] || lightVisit[i]) continue;
+
+				lightVisit[i] = true;
+				q.add(i);
+			}
 		}
+		marble[root].lightCount = count;
 	}
 
-	private static void checkHeavy(int root, int now) {
-		for (int next =  0; next < N; ++next) {
-			if (marble[now].heavy[next] == false) continue;
-			marble[root].heavy[next] = true;
-			checkHeavy(root, next);
+	/**
+	 * step 2 (2) - 무거운 구슬을 찾는 함수 (bfs)
+	 *
+	 * @param root
+	 */
+	private static void checkHeavy(int root) {
+		Queue<Integer> q = new LinkedList<>();
+
+		q.add(root);
+		heavyVisit[root] = true;
+
+		int count = -1;
+
+		while(!q.isEmpty()) {
+			int now = q.poll();
+			count++;
+
+			for (int i = 0; i < N; ++i) {
+				if (!marble[now].heavy[i] || heavyVisit[i]) continue;
+
+				heavyVisit[i] = true;
+				q.add(i);
+			}
 		}
+		marble[root].heavyCount = count;
 	}
 
+	/**
+	 * step 3 - 중간이 될 수 없는 구슬의 개수를 세는 함수
+	 *
+	 * 중간이 될 수 없는 조건
+	 * 1. 가벼운 구슬의 개수가 이미 중간값보다 많음
+	 * 2. 무거운 구슬의 개수가 이미 중간값보다 많음
+	 *
+	 * @return 중간이 될 수 없는 구슬의 개수
+	 */
 	private static int findNoMiddle() {
 		int mid = (N + 1) / 2;
 		int lightCount = mid - 1;

--- a/baekjoon/구슬찾기_2617.java
+++ b/baekjoon/구슬찾기_2617.java
@@ -1,0 +1,90 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+public class 구슬찾기_2617 {
+
+	private static int N, M;
+	private static Tree[] marble;
+
+	private static Set<Integer> lightSet;
+	private static Set<Integer> heavySet;
+
+	private static class Tree {
+		Set<Integer> light, heavy;
+
+		Tree() {
+			light = new HashSet<>();
+			heavy = new HashSet<>();
+		}
+	}
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		marble = new Tree[N];
+		for (int i = 0; i < N; ++i) {
+			marble[i] = new Tree();
+		}
+
+		for (int i = 0; i < M; ++i) {
+			st = new StringTokenizer(br.readLine());
+			int mh = Integer.parseInt(st.nextToken()) - 1;
+			int ml = Integer.parseInt(st.nextToken()) - 1;
+
+			marble[mh].light.add(ml);
+			marble[ml].heavy.add(mh);
+
+		}
+
+		for (int i = 0; i < N; ++i) {
+			lightSet = new HashSet<>();
+			heavySet = new HashSet<>();
+
+			checkLight(i, i);
+			checkHeavy(i, i);
+
+			marble[i].light.addAll(lightSet);
+			marble[i].heavy.addAll(heavySet);
+
+		}
+
+		System.out.println(findNoMiddle());
+	}
+
+	private static void checkLight(int root, int now) {
+		if (marble[now].light.isEmpty()) return;
+
+		for (int next : marble[now].light) {
+			lightSet.add(next);
+			checkLight(root, next);
+		}
+	}
+
+	private static void checkHeavy(int root, int now) {
+		if (marble[now].heavy.isEmpty()) return;
+
+		for (int next : marble[now].heavy) {
+			heavySet.add(next);
+			checkHeavy(root, next);
+		}
+	}
+
+	private static int findNoMiddle() {
+		int mid = (N + 1) / 2;
+		int lightCount = mid - 1;
+		int heavyCount = N - mid;
+
+		int noMid = 0;
+		for (int i = 0; i < N; ++i) {
+			if (marble[i].light.size() > lightCount
+				|| marble[i].heavy.size() > heavyCount) noMid++;
+		}
+
+		return noMid;
+	}
+}

--- a/baekjoon/주사위_굴리기_14499.java
+++ b/baekjoon/주사위_굴리기_14499.java
@@ -1,0 +1,126 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * 풀이시간 : 1시간
+ * 메모리 : 14,500 KB
+ * 시간 : 144 ms
+ * 시간복잡도 : O(N*M + K)
+ */
+public class 주사위_굴리기_14499 {
+	private static int N, M, r, c, K;
+	private static int[][] map;
+	private static int[] dice = {0, 0, 0, 0, 0, 0};
+	private static int[] dr = {0, 0, 0, -1, 1};
+	private static int[] dc = {0, 1, -1, 0, 0};
+	private static StringBuilder sb = new StringBuilder();
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		// step 1 - 입력
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		r = Integer.parseInt(st.nextToken());
+		c = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+
+		map = new int[N][M];
+		for (int i = 0; i < N; ++i) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < M; ++j) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		// step 2 - 주사위 굴리기
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < K; ++i) {
+			move(Integer.parseInt(st.nextToken()));
+		}
+
+		// step 3 - 출력
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		bw.write(sb.toString());
+
+		bw.close();
+		br.close();
+	}
+
+	/**
+	 * step 2 (1) - 주사위를 굴리는 함수
+	 *
+	 * 1. 새로운 (r, c)가 유효한가
+	 * 2. (r,c) : map == 0 인가
+	 * 		(yes) => dice 바닥(5)의 숫자를 map에 복사
+	 * 		(no) => map의 숫자를 dice 바닥(5)에 복사하고, map = 0
+	 * 3. 주사위 윗면 출력
+	 * @param dir 주사위가 구를 방향
+	 */
+	private static void move(int dir) {
+		int nr = r + dr[dir];
+		int nc = c + dc[dir];
+
+		if (!isValid(nr, nc)) return ;
+
+		r = nr;
+		c = nc;
+		setDice(dir);
+
+		if (map[r][c] == 0)
+			map[r][c] = dice[5];
+		else {
+			dice[5] = map[r][c];
+			map[r][c] = 0;
+		}
+
+		sb.append(dice[2]).append('\n');
+	}
+
+	/**
+	 * step 2 (2) - 주사위를 굴렸을 때 모양 결정하는 함수 (노가다 구현)
+	 *
+	 * @param dir 방향 (1 : 동 / 2 : 서 / 3 : 북 / 4 : 남)
+	 */
+	private static void setDice(int dir) {
+		int[] tmp = new int[6];
+
+		if (dir == 1) {
+			tmp[0] = dice[0];
+			tmp[1] = dice[5];
+			tmp[2] = dice[1];
+			tmp[3] = dice[2];
+			tmp[4] = dice[4];
+			tmp[5] = dice[3];
+		} else if (dir == 2) {
+			tmp[0] = dice[0];
+			tmp[1] = dice[2];
+			tmp[2] = dice[3];
+			tmp[3] = dice[5];
+			tmp[4] = dice[4];
+			tmp[5] = dice[1];
+		} else if (dir == 3) {
+			tmp[0] = dice[2];
+			tmp[1] = dice[1];
+			tmp[2] = dice[4];
+			tmp[3] = dice[3];
+			tmp[4] = dice[5];
+			tmp[5] = dice[0];
+		} else {
+			tmp[0] = dice[5];
+			tmp[1] = dice[1];
+			tmp[2] = dice[0];
+			tmp[3] = dice[3];
+			tmp[4] = dice[2];
+			tmp[5] = dice[4];
+		}
+
+		dice = tmp.clone();
+	}
+
+	private static boolean isValid(int r, int c) {
+		return 0 <= r && r < N && 0 <= c && c < M;
+	}
+}

--- a/baekjoon/트럭_13335.java
+++ b/baekjoon/트럭_13335.java
@@ -1,0 +1,73 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 풀이시간 : 25분
+ * 메모리 : 14456 KB
+ * 시간 : 144 ms
+ * 시간복잡도 : 최악의 경우(다리에 차 1대씩만 가능할 때) O(1000 * 100)
+ */
+public class 트럭_13335 {
+	private static int n, w, L;
+	private static int[] truck;
+
+	private static class Pair {
+		int w, time;
+
+		Pair(int n, int t) {
+			this.w = n;
+			this.time = t;
+		}
+	}
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		w = Integer.parseInt(st.nextToken());
+		L = Integer.parseInt(st.nextToken());
+
+		truck = new int[n];
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; ++i) {
+			truck[i] = Integer.parseInt(st.nextToken());
+		}
+
+		/**
+		 * 1초씩 시간 보내면서 체크함...노가다 뛰었다는 말...
+		 *
+		 * 1. 맨앞에 있는 트럭이 다리를 다 건넜는가?
+		 * 		(no) => 2번 진행
+		 * 		(yes) => poll 후에 2번 진행
+		 *
+		 * 2. 다리 위에 트럭이 더 올라갈 수 있는가?
+		 * 		(no) => 맨앞에 있는 트럭이 다리를 다 건널때까지 time++
+		 * 		(yes) => add (weight 증가)
+		 *
+		 * 3. 다리가 비었는가? (yes) => 끝
+		 */
+		int time = 0;
+		int weight = 0;
+		int i = 0;
+		Queue<Pair> bridge = new LinkedList<>();
+
+		while (true) {
+			if (!bridge.isEmpty() && (time - bridge.peek().time) == w)
+				weight -= bridge.poll().w;
+
+			if (i < n && weight + truck[i] <= L) {
+				weight += truck[i];
+				bridge.add(new Pair(truck[i], time));
+				i++;
+			}
+
+			time++;
+
+			if (bridge.isEmpty()) break;
+		}
+
+		System.out.println(time);
+	}
+}


### PR DESCRIPTION
늦어서 지송지송함다

## 주사위 굴리기
 * 풀이시간 : 1시간
 * 메모리 : 14,500 KB
 * 시간 : 144 ms
 * 시간복잡도 : O(N*M + K)
 
_저번에 삼성 기출에서 주사위굴리기2 풀어봐서 노가다로 주사위 굴려야하는 거 알고있었음...
근데 항상 헷갈리는 건 전개도에 써진 숫자를 안쪽으로 생각하고 개형도를 만들어야하는가,
 바깥쪽으로 생각하고 만들어야하는가,..................저번에 그거때문에 1시간 헤맴;;;_
..... => **정답 : 바깥쪽 (맞겠지?)**

## 트럭
 * 풀이시간 : 25분
 * 메모리 : 14456 KB
 * 시간 : 144 ms
 * 시간복잡도 : 최악의 경우(다리에 차 1대씩만 가능할 때) O(1000 * 100)
 * 
```java
while(true) { time++; }
```
이런식으로 진짜 1초씩 보내면서 계산함. 분명 1초씩 안해도 되겠지? 
근데 다리 위에 트럭이 여러대일 때 총 몇초 걸리는지 계산하는거 모르겠어서 진짜로 쌩으로 1초씩 흘려보냈다

## 구슬찾기
 * 풀이시간 : 1시간 반
 * 메모리 : 15960 KB
 * 시간 : 216 ms
 * 시간복잡도 : O(N * (N + E))
 
_왜케 쉬움? 했더니 메모리 & 시간 제약이 빡셌다.
트리 구조로 left에 가벼운 구슬 리스트, right에 무거운 구슬 리스트를 두는 방식을 선택(했었음)_

### 시도 1. hashSet 으로 left, right 구성, 재귀로 left & right 모두 찾기
 **메모리 초과!**
> 원인 : Integer 객체의 크기와 hashSet에서 버킷을 관리하는 방식때문인듯 함
> 해결책 : STL을 사용하지 말자

### 시도 2. boolean[]으로 left(light), right(heavy) 인 구슬을 true로 저장
**시간 초과!**
> 원인 
> (1) 재귀를 돌면서 left, right를 update함
> (2) 완성된 left, right 배열에서 각각 구슬의 개수 카운트
> 위 두 과정에서 반복문을 너무 많이 돈다
>
> 해결책 : 반복문 못줄이나?

### 시도 3. 자료구조 : boolean[] & left, right를 찾음과 동시에 개수 카운트
**통과!**
> 시도 2에서  (2) 과정을 없애고, (1)은 재귀가 아닌 bfs 선택 => visit, queue 활용해서 중복을 줄임